### PR TITLE
Fix: Circular error import

### DIFF
--- a/src/samplemaker/devices.py
+++ b/src/samplemaker/devices.py
@@ -196,9 +196,14 @@ from samplemaker import (
     _DevicePool,
 )
 from samplemaker.gdswriter import GDSWriter
-from samplemaker.layout import IncompatiblePortError
 from samplemaker.makers import make_sref, make_text
 from samplemaker.shapes import GeomGroup, Poly
+
+
+class IncompatiblePortError(RuntimeError):
+    """
+    Exception raised when trying to link incompatible ports.
+    """
 
 
 class DevicePort:

--- a/src/samplemaker/layout.py
+++ b/src/samplemaker/layout.py
@@ -99,7 +99,7 @@ from samplemaker import (
     _DeviceLocalParamPool,
     _DevicePool,
 )
-from samplemaker.devices import Device
+from samplemaker.devices import Device, IncompatiblePortError
 from samplemaker.gdsreader import GDSReader
 from samplemaker.gdswriter import GDSWriter
 from samplemaker.makers import make_aref, make_circle, make_path, make_text
@@ -406,12 +406,6 @@ class DeviceTableAnnotations:
         if self.to_poly:
             g.all_to_poly()
         return g
-
-
-class IncompatiblePortError(RuntimeError):
-    """
-    Exception raised when trying to link incompatible ports.
-    """
 
 
 class DeviceTable:


### PR DESCRIPTION
Move IncompatiblePortError error class to prevent circular import.