### PR TITLE
Fix: make_rounded_rect floating point precision

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 requires-python = ">=3.11,<3.15"
 license-files = ["LICENSE.md"]
 license = "BSD-3-Clause"
-version = "5.4.7"
+version = "5.4.8"
 dependencies = [
     "matplotlib>=3.10.5",
     "numpy==2.*",

--- a/src/samplemaker/makers.py
+++ b/src/samplemaker/makers.py
@@ -578,6 +578,10 @@ def make_rounded_rect(
     r1.poly_resize(corner_radius, layer, corner_radius > 0, resolution * 4)
     bb1 = r1.bounding_box()
     r1.scale(x0, y0, w0 / bb1.width, h0 / bb1.height)
+
+    bb1 = r1.bounding_box()
+    r1.translate(x0 - bb1.cx(), y0 - bb1.cy())
+
     if numkey != 5:
         xoff = -((numkey - 1) % 3 - 1)
         yoff = math.floor((9 - numkey) / 3) - 1

--- a/tests/test_makers.py
+++ b/tests/test_makers.py
@@ -493,10 +493,10 @@ def test_make_rounded_rect_noncenter_numkey() -> None:
         layer=16,
     )
     bb = rounded_rect_geom.bounding_box()
-    assert bb.urx() == pytest.approx(2.0, abs=1e-3)
-    assert bb.ury() == pytest.approx(3.0, abs=1e-3)
-    assert bb.width == pytest.approx(10.0, abs=1e-3)
-    assert bb.height == pytest.approx(6.0, abs=1e-3)
+    assert bb.urx() == pytest.approx(2.0)
+    assert bb.ury() == pytest.approx(3.0)
+    assert bb.width == pytest.approx(10.0)
+    assert bb.height == pytest.approx(6.0)
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -571,7 +571,7 @@ wheels = [
 
 [[package]]
 name = "samplemaker-sparrow"
-version = "5.4.6"
+version = "5.4.8"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib" },


### PR DESCRIPTION
This PR fixes `samplemaker.makers.make_rounded_rect()` slightly offsetting the generated geometry from its intended position. Tests have been made stricter to reflect this change.