### PR TITLE
Tests: Add tests to baselib

### DIFF
--- a/tests/test_baselib_devices.py
+++ b/tests/test_baselib_devices.py
@@ -1,0 +1,128 @@
+"""Tests for samplemaker.baselib.devices."""
+
+import pytest
+
+from samplemaker.baselib.devices import (
+    CrossMark,
+    DirectionalCoupler,
+    FocusingGratingCoupler,
+)
+
+
+def test_crossmark_layer_and_bbox_change_with_parameters() -> None:
+    base = CrossMark.build()
+    base.use_references = False
+    g_base = base.run()
+    bb_base = g_base.bounding_box()
+
+    assert g_base.get_layer_list() == {4}
+    assert bb_base.width == pytest.approx(40.0)
+    assert bb_base.height == pytest.approx(40.0)
+
+    changed = CrossMark.build()
+    changed.use_references = False
+    changed.set_param("length2", 20.0)
+    changed.set_param("layer", 9)
+    g_changed = changed.run()
+    bb_changed = g_changed.bounding_box()
+
+    assert g_changed.get_layer_list() == {9}
+    assert bb_changed.width > bb_base.width + 19.0
+    assert bb_changed.height > bb_base.height + 19.0
+
+
+def test_crossmark_mark_number_adds_corner_square() -> None:
+    no_mark = CrossMark.build()
+    no_mark.use_references = False
+    bb_no_mark = no_mark.run().bounding_box()
+
+    with_mark = CrossMark.build()
+    with_mark.use_references = False
+    with_mark.set_param("mark_number", 1)
+    with_mark.set_param("square_size", 12.0)
+    bb_with_mark = with_mark.run().bounding_box()
+
+    assert bb_with_mark.width > bb_no_mark.width
+    assert bb_with_mark.height > bb_no_mark.height
+
+
+def test_directional_coupler_ports_follow_parameters() -> None:
+    dev = DirectionalCoupler.build()
+    dev.use_references = False
+    dev.set_param("length", 30.0)
+    dev.set_param("input_len", 9.0)
+    dev.set_param("input_dist", 8.0)
+    dev.set_param("gap", 0.6)
+    dev.set_param("width", 0.4)
+    dev.run()
+
+    assert set(dev._ports) == {"p1", "p2", "p3", "p4"}
+
+    xp = (30.0 + 2 * 9.0) / 2
+    yp = 8.0 / 2 + 0.6 / 2 + 0.4 / 2
+    assert dev.get_port("p1").x0 == pytest.approx(-xp)
+    assert dev.get_port("p1").y0 == pytest.approx(yp)
+    assert dev.get_port("p1").angle_to_text() == "W"
+    assert dev.get_port("p2").x0 == pytest.approx(xp)
+    assert dev.get_port("p2").y0 == pytest.approx(yp)
+    assert dev.get_port("p2").angle_to_text() == "E"
+    assert dev.get_port("p3").x0 == pytest.approx(-xp)
+    assert dev.get_port("p3").y0 == pytest.approx(-yp)
+    assert dev.get_port("p3").angle_to_text() == "W"
+    assert dev.get_port("p4").x0 == pytest.approx(xp)
+    assert dev.get_port("p4").y0 == pytest.approx(-yp)
+    assert dev.get_port("p4").angle_to_text() == "E"
+
+
+def test_directional_coupler_geometry_changes_with_length_and_gap() -> None:
+    base = DirectionalCoupler.build()
+    base.use_references = False
+    bb_base = base.run().bounding_box()
+
+    longer = DirectionalCoupler.build()
+    longer.use_references = False
+    longer.set_param("length", 40.0)
+    bb_longer = longer.run().bounding_box()
+
+    wider_gap = DirectionalCoupler.build()
+    wider_gap.use_references = False
+    wider_gap.set_param("gap", 2.5)
+    bb_wider_gap = wider_gap.run().bounding_box()
+
+    assert bb_longer.width > bb_base.width + 15.0
+    assert bb_wider_gap.height > bb_base.height + 1.0
+
+
+def test_focusing_grating_coupler_has_expected_layers_and_port() -> None:
+    dev = FocusingGratingCoupler.build()
+    dev.use_references = False
+    geom = dev.run()
+
+    layers = geom.get_layer_list()
+    assert 1 in layers
+    assert 3 in layers
+
+    p1 = dev.get_port("p1")
+    assert p1.x0 == pytest.approx(-1.0)
+    assert p1.y0 == pytest.approx(0.0)
+    assert p1.angle_to_text() == "W"
+    assert p1.width == pytest.approx(dev.get_params()["w0"])
+
+
+def test_focusing_grating_coupler_bbox_changes_with_order_and_divergence() -> None:
+    base = FocusingGratingCoupler.build()
+    base.use_references = False
+    bb_base = base.run().bounding_box()
+
+    higher_order = FocusingGratingCoupler.build()
+    higher_order.use_references = False
+    higher_order.set_param("order", 25)
+    bb_higher_order = higher_order.run().bounding_box()
+
+    larger_divergence = FocusingGratingCoupler.build()
+    larger_divergence.use_references = False
+    larger_divergence.set_param("diverg_angle", 35.0)
+    bb_larger_divergence = larger_divergence.run().bounding_box()
+
+    assert bb_higher_order.width > bb_base.width
+    assert bb_larger_divergence.height > bb_base.height

--- a/tests/test_baselib_waveguides.py
+++ b/tests/test_baselib_waveguides.py
@@ -1,4 +1,5 @@
 """Tests for the base waveguide library in samplemaker.baselib.waveguides."""
+
 import math
 
 import pytest

--- a/tests/test_baselib_waveguides.py
+++ b/tests/test_baselib_waveguides.py
@@ -1,8 +1,12 @@
+"""Tests for the base waveguide library in samplemaker.baselib.waveguides."""
+import math
+
 import pytest
 
 import samplemaker.baselib.waveguides as smwvg
 import samplemaker.sequencer as smseq
-from samplemaker.shapes import Poly
+from samplemaker.devices import DevicePort
+from samplemaker.shapes import GeomGroup, Poly
 
 
 def test_base_waveguide_options(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -76,7 +80,6 @@ def test_base_waveguide_s_horizontal() -> None:
     assert bb.lly == pytest.approx(-state["w"] / 2)
     assert bb.urx() == pytest.approx(args[0])
     assert bb.ury() == pytest.approx(state["w"] / 2)
-
     assert state["x"] == pytest.approx(args[0])
     assert state["y"] == pytest.approx(0)
     assert state["a"] == pytest.approx(0)
@@ -99,7 +102,6 @@ def test_base_waveguide_s_vertical() -> None:
     assert bb.lly == pytest.approx(0)
     assert bb.urx() == pytest.approx(state["w"] / 2)
     assert bb.ury() == pytest.approx(args[0])
-
     assert state["x"] == pytest.approx(0)
     assert state["y"] == pytest.approx(args[0])
     assert state["a"] == pytest.approx(90)
@@ -115,9 +117,215 @@ def test_base_waveguide_s_zero_length() -> None:
 
     assert isinstance(g, smseq.GeomGroup)
     assert len(g.group) == 0
-
     assert state["x"] == pytest.approx(0)
     assert state["y"] == pytest.approx(0)
     assert state["a"] == pytest.approx(0)
     assert state["w"] == pytest.approx(0.4)
     assert state["__OL__"] == pytest.approx(0)
+
+
+def test_base_waveguide_b_positive_angle() -> None:
+    args = [90, 5]
+    state = {"w": 0.4, "x": 0, "y": 0, "a": 0, "__OL__": 0}
+    options = {"wgLayer": 2, "bendResolution": 30}
+
+    g = smwvg.BaseWaveguideB(args, state, options)
+
+    assert isinstance(g, GeomGroup)
+    assert len(g.group) == 1
+    assert isinstance(g.group[0], Poly)
+    assert g.group[0].layer == 2
+    assert state["x"] == pytest.approx(5)
+    assert state["y"] == pytest.approx(5)
+    assert state["a"] == pytest.approx(90)
+    assert state["__OL__"] == pytest.approx(5 * math.pi / 2)
+
+
+def test_base_waveguide_b_negative_angle() -> None:
+    args = [-90, 4]
+    state = {"w": 0.3, "x": 1, "y": 2, "a": 0, "__OL__": 0}
+    options = {"wgLayer": 1, "bendResolution": 20}
+
+    smwvg.BaseWaveguideB(args, state, options)
+
+    assert state["x"] == pytest.approx(5)
+    assert state["y"] == pytest.approx(-2)
+    assert state["a"] == pytest.approx(-90)
+    assert state["__OL__"] == pytest.approx(2 * math.pi)
+
+
+def test_base_waveguide_b_zero_angle() -> None:
+    args = [0, 3]
+    state = {"w": 0.4, "x": 2, "y": 3, "a": 45, "__OL__": 1}
+    options = {"wgLayer": 1, "bendResolution": 30}
+
+    g = smwvg.BaseWaveguideB(args, state, options)
+
+    assert isinstance(g, GeomGroup)
+    assert len(g.group) == 0
+    assert state == {"w": 0.4, "x": 2, "y": 3, "a": 45, "__OL__": 1}
+
+
+def test_base_waveguide_c_changes_state() -> None:
+    args = [2, 6]
+    state = {"w": 0.35, "x": 0, "y": 0, "a": 0, "__OL__": 0}
+    options = {"wgLayer": 7, "bendResolution": 40}
+
+    g = smwvg.BaseWaveguideC(args, state, options)
+
+    assert isinstance(g, GeomGroup)
+    assert len(g.group) == 1
+    assert state["x"] == pytest.approx(12)
+    assert state["y"] == pytest.approx(2)
+    assert state["a"] == pytest.approx(0)
+    assert state["__OL__"] > 12
+
+
+def test_base_waveguide_c_zero_radius() -> None:
+    args = [1, 0.01]  # radius is reduced by internal delta
+    state = {"w": 0.3, "x": 0, "y": 0, "a": 0, "__OL__": 0}
+    options = {"wgLayer": 1, "bendResolution": 10}
+
+    g = smwvg.BaseWaveguideC(args, state, options)
+
+    assert isinstance(g, GeomGroup)
+    assert len(g.group) == 0
+    assert state["x"] == pytest.approx(0)
+    assert state["y"] == pytest.approx(0)
+    assert state["a"] == pytest.approx(0)
+    assert state["__OL__"] == pytest.approx(0)
+
+
+def test_base_waveguide_t_uses_default_width() -> None:
+    args = [10, -1]
+    state = {"w": 0.4, "x": 0, "y": 0, "a": 0, "__OL__": 0}
+    options = {"wgLayer": 3, "bendResolution": 30, "defaultWidth": 0.8}
+
+    g = smwvg.BaseWaveguideT(args, state, options)
+
+    assert isinstance(g, GeomGroup)
+    assert len(g.group) == 1
+    assert state["x"] == pytest.approx(10)
+    assert state["y"] == pytest.approx(0)
+    assert state["w"] == pytest.approx(0.8)
+    assert state["__OL__"] == pytest.approx(10)
+
+
+def test_base_waveguide_t_zero_length() -> None:
+    args = [0, 1.2]
+    state = {"w": 0.4, "x": 4, "y": 5, "a": 90, "__OL__": 3}
+    options = {"wgLayer": 1, "bendResolution": 30, "defaultWidth": 0.7}
+
+    g = smwvg.BaseWaveguideT(args, state, options)
+
+    assert isinstance(g, GeomGroup)
+    assert len(g.group) == 0
+    assert state == {"w": 0.4, "x": 4, "y": 5, "a": 90, "__OL__": 3}
+
+
+def test_base_waveguide_off() -> None:
+    args = [2]
+    state = {"w": 0.3, "x": 0, "y": 0, "a": 0, "__OL__": 1}
+    options = {"wgLayer": 1, "bendResolution": 30}
+
+    g = smwvg.BaseWaveguideOFF(args, state, options)
+
+    assert isinstance(g, GeomGroup)
+    assert len(g.group) == 0
+    assert state["x"] == pytest.approx(0)
+    assert state["y"] == pytest.approx(2)
+    assert state["__OL__"] == pytest.approx(1)
+
+
+def test_base_waveguide_commands() -> None:
+    commands = smwvg.BaseWaveguideCommands()
+
+    assert commands["INIT"][0] == 0
+    assert commands["S"][0] == 1
+    assert commands["B"][0] == 2
+    assert commands["C"][0] == 2
+    assert commands["T"][0] == 2
+    assert commands["OFF"][0] == 1
+    assert commands["S"][1] is smwvg.BaseWaveguideS
+    assert commands["B"][1] is smwvg.BaseWaveguideB
+
+
+def test_base_waveguide_sequencer_runs() -> None:
+    seq = [["S", 5], ["T", 2, 0.5]]
+    s = smwvg.BaseWaveguideSequencer(seq)
+
+    g = s.run()
+
+    assert isinstance(s, smseq.Sequencer)
+    assert isinstance(g, GeomGroup)
+    assert len(g.group) == 2
+    assert s.state["x"] == pytest.approx(7)
+    assert s.state["y"] == pytest.approx(0)
+    assert s.state["w"] == pytest.approx(0.5)
+
+
+def test_base_waveguide_connector_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_connect(
+        port1: DevicePort, port2: DevicePort, radius: float
+    ) -> tuple[bool, list[list[object]]]:
+        captured["radius"] = radius
+        captured["ports"] = (port1, port2)
+        return True, [["S", 1]]
+
+    class FakeSequencer:
+        def __init__(self, seq: list[list[object]]) -> None:
+            captured["seq"] = seq
+            self.options = {"wgLayer": 99}
+
+        def run(self) -> GeomGroup:
+            captured["run_called"] = True
+            return GeomGroup()
+
+    monkeypatch.setattr(smwvg, "WaveguideConnect", fake_connect)
+    monkeypatch.setattr(smwvg, "BaseWaveguideSequencer", FakeSequencer)
+
+    p1 = smwvg.BaseWaveguidePort(0, 0, "E")
+    p2 = smwvg.BaseWaveguidePort(10, 0, "W")
+    g = smwvg.BaseWaveguideConnector(p1, p2)
+
+    assert isinstance(g, GeomGroup)
+    assert captured["radius"] == smwvg.BaseWaveguideConnectorOptions["bending_radius"]
+    assert captured["seq"] == [["S", 1]]
+    assert captured["run_called"] is True
+
+
+def test_base_waveguide_connector_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_connect(
+        port1: DevicePort, port2: DevicePort, radius: float
+    ) -> tuple[bool, list[list[object]]]:
+        _ = (port1, port2, radius)
+        return False, []
+
+    monkeypatch.setattr(smwvg, "WaveguideConnect", fake_connect)
+
+    p1 = smwvg.BaseWaveguidePort(0, 0, "E")
+    p2 = smwvg.BaseWaveguidePort(1, 1, "N")
+    g = smwvg.BaseWaveguideConnector(p1, p2)
+
+    assert isinstance(g, GeomGroup)
+    assert len(g.group) == 0
+
+
+@pytest.mark.parametrize(
+    ("orient", "expected"),
+    [
+        ("East", "E"),
+        ("W", "W"),
+        ("north", "N"),
+        ("s", "S"),
+    ],
+)
+def test_base_waveguide_port_orientation(orient: str, expected: str) -> None:
+    port = smwvg.BaseWaveguidePort(3, 4, orient=orient, width=0.45, name="io")
+
+    assert port.angle_to_text() == expected
+    assert port.width == pytest.approx(0.45)
+    assert port.name == "io"
+    assert port.connector_function is smwvg.BaseWaveguideConnector

--- a/tests/test_baselib_waveguides.py
+++ b/tests/test_baselib_waveguides.py
@@ -1,0 +1,123 @@
+import pytest
+
+import samplemaker.baselib.waveguides as smwvg
+import samplemaker.sequencer as smseq
+from samplemaker.shapes import Poly
+
+
+def test_base_waveguide_options(monkeypatch: pytest.MonkeyPatch) -> None:
+    called = []
+
+    def mock_default_options() -> dict:
+        called.append(True)
+        return {}
+
+    monkeypatch.setattr(smseq, "default_options", mock_default_options)
+    opts = smwvg.BaseWaveguideOptions()
+    assert called == [True]
+    assert isinstance(opts, dict)
+    assert "wgLayer" in opts
+    assert "bendResolution" in opts
+    assert "defaultWidth" in opts
+    assert opts["wgLayer"] == 1
+    assert opts["bendResolution"] == 30
+    assert opts["defaultWidth"] == 0.3
+
+
+def test_base_waveguide_state() -> None:
+    state = smwvg.BaseWaveguideState()
+    assert isinstance(state, smseq.SequencerState)
+    assert "w" in state.state
+    assert state.state["w"] == 0
+
+
+def test_base_waveguide_init(monkeypatch: pytest.MonkeyPatch) -> None:
+    called = []
+
+    def mock_init_state(state: dict, options: dict) -> None:
+        called.append(state.copy())
+
+    monkeypatch.setattr(smseq, "__initState", mock_init_state)
+    state = smseq.SequencerState()
+    options = {"defaultWidth": 0.5, "__no_init__": False}
+    smwvg.BaseWaveguideINIT(state.state, options)
+    assert len(called) == 1
+    assert "w" not in called[0]  # init first
+    assert state.state["w"] == 0.5
+
+
+def test_base_waveguide_init_no_init(monkeypatch: pytest.MonkeyPatch) -> None:
+    called = []
+
+    def mock_init_state(state: dict, options: dict) -> None:
+        called.append(state.copy())
+
+    monkeypatch.setattr(smseq, "__initState", mock_init_state)
+    state = smseq.SequencerState()
+    options = {"defaultWidth": 0.5, "__no_init__": True}
+    smwvg.BaseWaveguideINIT(state.state, options)
+    assert len(called) == 1
+    assert "w" not in called[0]  # init first
+    assert "w" not in state.state  # No init, so w should not be set
+
+
+def test_base_waveguide_s_horizontal() -> None:
+    args = [10]
+    state = {"w": 0.4, "x": 0, "y": 0, "a": 0, "__OL__": 0}
+    options = {"wgLayer": 1, "bendResolution": 30}
+    g = smwvg.BaseWaveguideS(args, state, options)
+
+    assert isinstance(g, smseq.GeomGroup)
+    assert len(g.group) == 1
+    assert isinstance(g.group[0], Poly)
+    assert g.group[0].layer == 1
+    bb = g.bounding_box()
+    assert bb.llx == pytest.approx(0)
+    assert bb.lly == pytest.approx(-state["w"] / 2)
+    assert bb.urx() == pytest.approx(args[0])
+    assert bb.ury() == pytest.approx(state["w"] / 2)
+
+    assert state["x"] == pytest.approx(args[0])
+    assert state["y"] == pytest.approx(0)
+    assert state["a"] == pytest.approx(0)
+    assert state["w"] == 0.4
+    assert state["__OL__"] == pytest.approx(args[0])
+
+
+def test_base_waveguide_s_vertical() -> None:
+    args = [10]
+    state = {"w": 0.4, "x": 0, "y": 0, "a": 90, "__OL__": 0}
+    options = {"wgLayer": 1, "bendResolution": 30}
+    g = smwvg.BaseWaveguideS(args, state, options)
+
+    assert isinstance(g, smseq.GeomGroup)
+    assert len(g.group) == 1
+    assert isinstance(g.group[0], Poly)
+    assert g.group[0].layer == 1
+    bb = g.bounding_box()
+    assert bb.llx == pytest.approx(-state["w"] / 2)
+    assert bb.lly == pytest.approx(0)
+    assert bb.urx() == pytest.approx(state["w"] / 2)
+    assert bb.ury() == pytest.approx(args[0])
+
+    assert state["x"] == pytest.approx(0)
+    assert state["y"] == pytest.approx(args[0])
+    assert state["a"] == pytest.approx(90)
+    assert state["w"] == 0.4
+    assert state["__OL__"] == pytest.approx(args[0])
+
+
+def test_base_waveguide_s_zero_length() -> None:
+    args = [0]
+    state = {"w": 0.4, "x": 0, "y": 0, "a": 0, "__OL__": 0}
+    options = {"wgLayer": 1, "bendResolution": 30}
+    g = smwvg.BaseWaveguideS(args, state, options)
+
+    assert isinstance(g, smseq.GeomGroup)
+    assert len(g.group) == 0
+
+    assert state["x"] == pytest.approx(0)
+    assert state["y"] == pytest.approx(0)
+    assert state["a"] == pytest.approx(0)
+    assert state["w"] == pytest.approx(0.4)
+    assert state["__OL__"] == pytest.approx(0)


### PR DESCRIPTION
This PR adds tests for the following:
- `src/samplemaker/baselib/devices.py`
- `src/samplemaker/baselib/waveguides.py`

Resolves #26.