### PR TITLE
Fix: Various bugfixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 requires-python = ">=3.11,<3.15"
 license-files = ["LICENSE.md"]
 license = "BSD-3-Clause"
-version = "5.4.9"
+version = "5.4.10"
 dependencies = ["asteval>=1.0.9", "matplotlib>=3.10.5", "numpy==2.*"]
 classifiers = [
     "Programming Language :: C++",

--- a/src/samplemaker/devices.py
+++ b/src/samplemaker/devices.py
@@ -825,8 +825,19 @@ class Device:
         -------
         None
 
+        Raises
+        ------
+        ValueError
+            If the port is not defined by the device.
+
         """
         lports = self._localp["_ports_"]
+        if portname not in lports:
+            msg = (
+                f"Could not find port named {portname} in {self._name} as it was "
+                f"not defined by device."
+            )
+            raise ValueError(msg)
         if portname in lports:
             self._localp["_ports_"].pop(portname)
 

--- a/src/samplemaker/devices.py
+++ b/src/samplemaker/devices.py
@@ -838,8 +838,7 @@ class Device:
                 f"not defined by device."
             )
             raise ValueError(msg)
-        if portname in lports:
-            self._localp["_ports_"].pop(portname)
+        self._localp["_ports_"].pop(portname)
 
     def set_param(self, param_name: str, value: Any) -> None:  # noqa: ANN401
         """Change a paramter. To be called after build().

--- a/src/samplemaker/layout.py
+++ b/src/samplemaker/layout.py
@@ -189,7 +189,15 @@ class MarkerSet(Marker):
         ydist : float, optional
             Y-distance between two markers, by default 1000.
 
+        Raises
+        ------
+        ValueError
+            Raised if mset is not 1, 2 or 4.
+
         """
+        if mset not in (1, 2, 4):
+            msg = f"Invalid mset value. Expected 1, 2 or 4. Got {mset} instead."
+            raise ValueError(msg)
         super().__init__(name, dev, x0, y0)
         self.mset = mset
         self.xdist = xdist

--- a/src/samplemaker/layout.py
+++ b/src/samplemaker/layout.py
@@ -241,7 +241,7 @@ class MarkerSet(Marker):
                 0,
                 self.ydist,
             )
-        return g
+        return g.translate(self.x0, self.y0)
 
 
 class DeviceTableAnnotations:

--- a/src/samplemaker/phc.py
+++ b/src/samplemaker/phc.py
@@ -333,7 +333,7 @@ class Crystal:
         nx = _legacy.ensure_arg_type("nx", nx)
         ny = _legacy.ensure_arg_type("ny", ny)
 
-        if nx == 0 & ny == 0:
+        if nx == 0 and ny == 0:
             return cls(np.array([0]), np.array([0]), np.ones((nparams, 1)))
 
         x1 = np.array(list(range(-nx, nx + 1)))

--- a/src/samplemaker/shapes.py
+++ b/src/samplemaker/shapes.py
@@ -3364,9 +3364,12 @@ class SRef(RefBase):
             bb = self.group.bounding_box()
         p = bb.to_poly()
         p.scale(0, 0, self.mag, self.mag)
-        p.rotate_translate(self.x0, self.y0, self.angle)
         if self.mirror:
-            p.mirror_y(self.y0)
+            p.mirror_y(0)
+        if self.angle != 0:
+            p.rotate_translate(self.x0, self.y0, self.angle)
+        else:
+            p.translate(self.x0, self.y0)
         return p.bounding_box()
 
     def place_group(self, flat_group: GeomGroup) -> GeomGroup:

--- a/src/samplemaker/shapes.py
+++ b/src/samplemaker/shapes.py
@@ -892,8 +892,8 @@ class GeomGroup:
             True if coordinate is inside the polygon.
 
         """
-        for i in range(len(self.group)):
-            if isinstance(self.group[i], SRef) and self.group[i].point_inside(x, y):
+        for geom in self.group:
+            if isinstance(geom, Poly) and geom.point_inside(x, y):
                 return True
         return False
 

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -250,12 +250,8 @@ class TestDevice:
         dummy_device.remove_localport("test")
         assert "test" not in dummy_device._localp["_ports_"]
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="remove_localport should raise for missing port but currently does not",
-    )
     def test_remove_localport_unknown_raises(self, dummy_device: smdev.Device) -> None:
-        with pytest.raises(ValueError, match="Could not find local port"):
+        with pytest.raises(ValueError, match="Could not find port"):
             dummy_device.remove_localport("missing")
 
     def test_get_port_raises_for_missing_port(self, dummy_device: smdev.Device) -> None:

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -116,9 +116,6 @@ class TestMarkerSet:
         with pytest.raises(ValueError, match="Invalid mset value"):
             smlay.MarkerSet(name, dev, mset=0)
 
-    @pytest.mark.xfail(
-        reason="Geometry is not translated correctly for mset==1", strict=True
-    )
     def test_markerset_get_geom_mset1(self) -> None:
         name = "TestMarkerSet"
         dev = CrossMark.build()

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -110,7 +110,6 @@ class TestMarkerSet:
         assert markerset.xdist == 1000
         assert markerset.ydist == 1000
 
-    @pytest.mark.xfail(reason="Invalid mset silently ignored", strict=True)
     def test_markerset_init_raises_on_invalid_mset(self) -> None:
         name = "TestMarkerSet"
         dev = CrossMark.build()

--- a/tests/test_phc.py
+++ b/tests/test_phc.py
@@ -212,14 +212,12 @@ def test_triangular_box_n1_n1_exact_coordinates() -> None:
     assert _site_set(c.xpts, c.ypts) == expected_site_set
 
 
-@pytest.mark.xfail(
-    reason="Known bug in triangular_box: uses bitwise '&' in zero-dimension check.",
-    strict=True,
-)
-def test_triangular_box_nx0_ny1_is_not_single_origin_site() -> None:
+def test_triangular_box_nx0_ny1_exact_coordinates() -> None:
     c = Crystal.triangular_box(nx=0, ny=1, nparams=1)
-    assert c.xpts.size > 1
-    assert not (c.xpts.size == 1 and c.ypts.size == 1)
+    assert c.ypts.size == 3
+    assert c.params.shape == (1, 3)
+    assert c.xpts == pytest.approx([0.0, 0.0, 0.0])
+    assert c.ypts == pytest.approx([-np.sqrt(3), 0.0, np.sqrt(3)])
 
 
 def test_triangular_heterophc_is_symmetric_for_integer_nx() -> None:

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -1775,7 +1775,7 @@ class TestGeomGroup:
 
     @pytest.mark.parametrize(
         "point",
-        [((2.0, 4.0), False), ((-1.0, -1.0), False)],
+        [(2.0, 4.0), (-1.0, -1.0)],
     )
     def test_in_polygons_srefs_always_false(
         self, point: tuple[float, float], sref_obj: sp.SRef

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -890,12 +890,7 @@ class TestSRef:
         assert bb.cx == pytest.approx(sref.x0 + pool_box.cx * sref.mag)
         assert bb.cy == pytest.approx(sref.y0 + pool_box.cy * sref.mag)
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="Known mismatch: SRef.bounding_box does not match placed "
-        "mirrored/rotated geometry.",
-    )
-    def test_bounding_box_mismatch_for_mirrored_rotated_sref_is_documented(
+    def test_bounding_box_matches_placed_group_for_mirrored_rotated_sref(
         self, sref_obj: sp.SRef, geomgroup_obj: sp.GeomGroup
     ) -> None:
         sref_obj.mag = 2.0
@@ -1067,12 +1062,7 @@ class TestAref:
         placed = aref_obj.place_group(geomgroup_obj.flatten())
         assert len(placed.group) == aref_kwargs.ncols * aref_kwargs.nrows
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="Known mismatch: ARef.bounding_box does not match placed "
-        "mirrored/rotated array geometry.",
-    )
-    def test_bounding_box_mismatch_for_mirrored_rotated_array_is_documented(
+    def test_bounding_box_matches_placed_group_for_mirrored_rotated_array(
         self, aref_obj: sp.ARef, geomgroup_obj: sp.GeomGroup
     ) -> None:
         aref_obj.mag = 2.0

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -1762,28 +1762,28 @@ class TestGeomGroup:
         ):
             g.find_matching_patterns(pattern, layer)
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="in_polygons erronously checks for SRefs "
-        "in the geometry group instead of Poly objects.",
+    @pytest.mark.parametrize(
+        ("point", "expected"),
+        [((1.0, 1.0), True), ((1.999, 1.999), True), ((2.0, 2.0), False)],
     )
-    def test_in_polygons_returns_true_for_point_in_polygon(self) -> None:
+    def test_in_polygons(self, point: tuple[float, float], expected: bool) -> None:
         layer = 9
         g = sp.Box(0.0, 0.0, 2.0, 2.0).to_rect()
         g.set_layer(layer)
 
-        assert g.in_polygons(1.0, 1.0) is True
+        assert g.in_polygons(point[0], point[1]) is expected
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="in_polygons erronously checks for SRefs "
-        "in the geometry group instead of Poly objects.",
+    @pytest.mark.parametrize(
+        "point",
+        [((2.0, 4.0), False), ((-1.0, -1.0), False)],
     )
-    def test_in_polygons_sref_raises_attribute_error(self, sref_obj: sp.SRef) -> None:
+    def test_in_polygons_srefs_always_false(
+        self, point: tuple[float, float], sref_obj: sp.SRef
+    ) -> None:
         g = sp.GeomGroup()
         g.add(sref_obj)
 
-        assert g.in_polygons(0.0, 0.0) is False
+        assert g.in_polygons(point[0], point[1]) is False
 
     def test_in_polygons_returns_false_for_empty_group(self) -> None:
         g = sp.GeomGroup()


### PR DESCRIPTION
- Fixed bitwise operator check in `phc.Crystal.triangular_box()` leading to incorrect geometry when `nx` or `ny` was zero.
- Added check for valid `mset` in init of `layout.MarkerSet`.
- Fixed marker set not being properly translated for `mset=1`.
- Added check for invalid port in `devices.Device.remove_localport()`.
- Adjusted transformation order when calculating `shapes.SRef` bounding boxes to match order found in `place_group` methods.
- Fixed `shapes.GeomGroup.in_polygons()` incorrectly checking for `SRef` objects instead of `Poly` objects, leading to an attribute error.