### PR TITLE
Feature: Improve PhC generation time

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 requires-python = ">=3.11,<3.15"
 license-files = ["LICENSE.md"]
 license = "BSD-3-Clause"
-version = "5.4.10"
+version = "5.5.1"
 dependencies = ["asteval>=1.0.9", "matplotlib>=3.10.5", "numpy==2.*"]
 classifiers = [
     "Programming Language :: C++",

--- a/src/samplemaker/phc.py
+++ b/src/samplemaker/phc.py
@@ -42,9 +42,7 @@ from samplemaker import _legacy
 from samplemaker.layout import LayoutPool
 from samplemaker.shapes import GeomGroup, Poly
 
-CELLFUN_TYPE: TypeAlias = Callable[
-    [float, float, Sequence[float] | str], GeomGroup | int
-]
+CELLFUN_TYPE: TypeAlias = Callable[[float, float, Sequence[float]], GeomGroup]
 
 
 class Crystal:
@@ -450,9 +448,7 @@ class Crystal:
         return heterophc
 
 
-def make_phc_circle(
-    x: float, y: float, params: Sequence[float] | str
-) -> GeomGroup | int:
+def make_phc_circle(x: float, y: float, params: Sequence[float]) -> GeomGroup:
     """Create a circular unit cell for a photonic crystal.
 
     Parameters
@@ -461,16 +457,14 @@ def make_phc_circle(
         x-coordinate of the center of the circle.
     y : float
         y-coordinate of the center of the circle.
-    params : Sequence[float] | str
-        Parameters for the unit cell. If "test" is passed, the function returns the
-        number of parameters required to draw the unit cell. Otherwise, it should be a
-        sequence containing the radius of the circle.
+    params : Sequence[float]
+        Parameters for the unit cell. It should be a sequence containing the radius of
+        the circle.
 
     Returns
     -------
-    GeomGroup | int
-        A geometry containing the circular unit cell, or the number of parameters
-        required if "test" is passed as params.
+    GeomGroup
+        A geometry containing the circular unit cell.
 
     Raises
     ------
@@ -478,20 +472,10 @@ def make_phc_circle(
         If an invalid string parameter is passed to the function.
 
     """
-    if isinstance(params, str):
-        if params == "test":
-            return 1
-        msg = (
-            f"Invalid string parameter '{params}' "
-            "passed to make_phc_circle. Expected 'test'."
-        )
-        raise TypeError(msg)
     return sm.make_circle(x, y, params[0], 0)
 
 
-def make_phc_circle_ref(
-    x: float, y: float, params: Sequence[float] | str
-) -> GeomGroup | int:
+def make_phc_circle_ref(x: float, y: float, params: Sequence[float]) -> GeomGroup:
     """Create a circular unit cell for a photonic crystal using a circle reference.
 
     Parameters
@@ -500,16 +484,14 @@ def make_phc_circle_ref(
         x-coordinate of the center of the circle.
     y : float
         y-coordinate of the center of the circle.
-    params : Sequence[float] | str
-        Parameters for the unit cell. If "test" is passed, the function returns the
-        number of parameters required to draw the unit cell. Otherwise, it should be a
-        sequence containing the radius of the circle.
+    params : Sequence[float]
+        Parameters for the unit cell. It should be a sequence containing the radius of
+        the circle.
 
     Returns
     -------
-    GeomGroup | int
-        A geometry containing the circular unit cell, or the number of parameters
-        required if "test" is passed as params.
+    GeomGroup
+        A geometry containing the circular unit cell.
 
     Raises
     ------
@@ -517,14 +499,6 @@ def make_phc_circle_ref(
         If an invalid string parameter is passed to the function.
 
     """
-    if isinstance(params, str):
-        if params == "test":
-            return 1
-        msg = (
-            f"Invalid string parameter '{params}' "
-            "passed to make_phc_circle_ref. Expected 'test'."
-        )
-        raise TypeError(msg)
     return sm.make_sref(x, y, "_CIRCLE", LayoutPool["_CIRCLE"], mag=params[0])
 
 
@@ -576,14 +550,6 @@ def make_phc(
             "The 'name' parameter is deprecated and will be removed in future versions."
         )
         warnings.warn(msg, DeprecationWarning, stacklevel=2)
-
-    nargs = cellfun(0, 0, "test")
-    if not isinstance(nargs, int):
-        msg = (
-            "The cellfun function must return an integer when called with 'test' as "
-            "the params argument."
-        )
-        raise TypeError(msg)
 
     phc = GeomGroup()
     xpts_scaled = np.asarray(crystal.xpts) * scaling
@@ -654,14 +620,6 @@ def make_phc_inpoly(
             "The 'name' parameter is deprecated and will be removed in future versions."
         )
         warnings.warn(msg, DeprecationWarning, stacklevel=2)
-
-    nargs = cellfun(0, 0, "test")
-    if not isinstance(nargs, int):
-        msg = (
-            "The cellfun function must return an integer when called with 'test' as "
-            "the params argument."
-        )
-        raise TypeError(msg)
 
     phc = GeomGroup()
     xpts_scaled = np.asarray(crystal.xpts) * scaling

--- a/src/samplemaker/phc.py
+++ b/src/samplemaker/phc.py
@@ -466,11 +466,6 @@ def make_phc_circle(x: float, y: float, params: Sequence[float]) -> GeomGroup:
     GeomGroup
         A geometry containing the circular unit cell.
 
-    Raises
-    ------
-    TypeError
-        If an invalid string parameter is passed to the function.
-
     """
     return sm.make_circle(x, y, params[0], 0)
 
@@ -493,13 +488,23 @@ def make_phc_circle_ref(x: float, y: float, params: Sequence[float]) -> GeomGrou
     GeomGroup
         A geometry containing the circular unit cell.
 
-    Raises
-    ------
-    TypeError
-        If an invalid string parameter is passed to the function.
-
     """
     return sm.make_sref(x, y, "_CIRCLE", LayoutPool["_CIRCLE"], mag=params[0])
+
+
+def _validate_crystal(crystal: Crystal) -> None:
+    if len(crystal.xpts) != len(crystal.ypts):
+        msg = "The number of x-coordinates must match the number of y-coordinates."
+        raise ValueError(msg)
+    if len(crystal.xpts) == 0:
+        # We allow empty crystals
+        return
+    if crystal.params.ndim != 2:
+        msg = "The params array must be 2-dimensional."
+        raise ValueError(msg)
+    if crystal.params.shape[1] != len(crystal.xpts):
+        msg = "The number of parameter sets must match the number of lattice sites."
+        raise ValueError(msg)
 
 
 def make_phc(
@@ -540,9 +545,11 @@ def make_phc(
     Raises
     ------
     TypeError
-        If the cellfun function does not return an integer when called with "test" as
-        the params argument, or if it does not return a GeomGroup when called with
+        If the cellfun function does not return a GeomGroup when called with
         valid parameters.
+    ValueError
+        If the passed crystal has inconsistent dimensions or parameters or if the number
+        of cell parameters does not match the number of parameter sets in the crystal.
 
     """
     if name:
@@ -550,8 +557,19 @@ def make_phc(
             "The 'name' parameter is deprecated and will be removed in future versions."
         )
         warnings.warn(msg, DeprecationWarning, stacklevel=2)
+    _validate_crystal(crystal)
 
     phc = GeomGroup()
+    if len(crystal.xpts) == 0:
+        return phc
+
+    if len(cellparams) != crystal.params.shape[0]:
+        msg = (
+            "The number of cell parameters must match the number of parameter sets "
+            "in the crystal."
+        )
+        raise ValueError(msg)
+
     xpts_scaled = np.asarray(crystal.xpts) * scaling
     ypts_scaled = np.asarray(crystal.ypts) * scaling
     params = np.asarray(crystal.params) * np.asarray(cellparams)[:, np.newaxis]
@@ -610,9 +628,11 @@ def make_phc_inpoly(
     Raises
     ------
     TypeError
-        If the cellfun function does not return an integer when called with "test" as
-        the params argument, or if it does not return a GeomGroup when called with
+        If the cellfun function does not return a GeomGroup when called with
         valid parameters.
+    ValueError
+        If the passed crystal has inconsistent dimensions or parameters or if the number
+        of cell parameters does not match the number of parameter sets in the crystal.
 
     """
     if name:
@@ -620,8 +640,19 @@ def make_phc_inpoly(
             "The 'name' parameter is deprecated and will be removed in future versions."
         )
         warnings.warn(msg, DeprecationWarning, stacklevel=2)
+    _validate_crystal(crystal)
 
     phc = GeomGroup()
+    if len(crystal.xpts) == 0:
+        return phc
+
+    if len(cellparams) != crystal.params.shape[0]:
+        msg = (
+            "The number of cell parameters must match the number of parameter sets "
+            "in the crystal."
+        )
+        raise ValueError(msg)
+
     xpts_scaled = np.asarray(crystal.xpts) * scaling
     ypts_scaled = np.asarray(crystal.ypts) * scaling
     params = np.asarray(crystal.params) * np.asarray(cellparams)[:, np.newaxis]

--- a/src/samplemaker/phc.py
+++ b/src/samplemaker/phc.py
@@ -530,10 +530,9 @@ def make_phc(
         Position x-coordinate in um.
     y0 : float
         Position y-coordinate in um.
-    cellfun : Callable[[float, float, list[float] | str], GeomGroup], optional
-        A function of the type fun(x,y,params) that returns the geometry of the unit
-        cell. It should also return the number of parameters required to draw the unit
-        cell if "test" is passed as params, by default make_phc_circle.
+    cellfun : Callable[[float, float, Sequence[float]], GeomGroup], optional
+        A function of the type fun(x,y,params) that returns the geometry of a single
+        site in the crystal.
     name : str, optional
         DEPRECATED. Name of the crystal, by default "".
 
@@ -613,10 +612,9 @@ def make_phc_inpoly(
         Position x-coordinate in um.
     y0 : float
         Position y-coordinate in um.
-    cellfun : Callable[[float, float, list[float] | str], GeomGroup], optional
-        A function of the type fun(x,y,params) that returns the geometry of the unit
-        cell. It should also return the number of parameters required to draw the unit
-        cell if "test" is passed as params, by default make_phc_circle.
+    cellfun : Callable[[float, float, Sequence[float]], GeomGroup], optional
+        A function of the type fun(x,y,params) that returns the geometry of a single
+        site in the crystal.
     name : str, optional
         DEPRECATED. Name of the crystal, by default "".
 

--- a/src/samplemaker/phc.py
+++ b/src/samplemaker/phc.py
@@ -586,20 +586,18 @@ def make_phc(
         raise TypeError(msg)
 
     phc = GeomGroup()
-    for i in range(len(crystal.xpts)):
-        xpos = crystal.xpts[i] * scaling
-        ypos = crystal.ypts[i] * scaling
-        params = [0.0] * nargs
-        for j in range(nargs):
-            params[j] = crystal.params[j, i] * cellparams[j]
-        g = cellfun(xpos, ypos, params)
+    xpts_scaled = np.asarray(crystal.xpts) * scaling
+    ypts_scaled = np.asarray(crystal.ypts) * scaling
+    params = np.asarray(crystal.params) * np.asarray(cellparams)[:, np.newaxis]
+    for i, (x, y) in enumerate(zip(xpts_scaled, ypts_scaled, strict=True)):
+        g = cellfun(x, y, params[:, i].tolist())
         if not isinstance(g, GeomGroup):
             msg = (
                 "The cellfun function must return a GeomGroup when called with "
                 "valid parameters."
             )
             raise TypeError(msg)
-        phc += g
+        phc.group.extend(g.group)
 
     phc.translate(x0, y0)
     return phc
@@ -666,21 +664,20 @@ def make_phc_inpoly(
         raise TypeError(msg)
 
     phc = GeomGroup()
-    for i in range(len(crystal.xpts)):
-        xpos = crystal.xpts[i] * scaling
-        ypos = crystal.ypts[i] * scaling
-        if poly.point_inside(xpos, ypos):
-            params = [0.0] * nargs
-            for j in range(nargs):
-                params[j] = crystal.params[j, i] * cellparams[j]
-            g = cellfun(xpos, ypos, params)
-            if not isinstance(g, GeomGroup):
-                msg = (
-                    "The cellfun function must return a GeomGroup when called with "
-                    "valid parameters."
-                )
-                raise TypeError(msg)
-            phc += g
+    xpts_scaled = np.asarray(crystal.xpts) * scaling
+    ypts_scaled = np.asarray(crystal.ypts) * scaling
+    params = np.asarray(crystal.params) * np.asarray(cellparams)[:, np.newaxis]
+    for i, (x, y) in enumerate(zip(xpts_scaled, ypts_scaled, strict=True)):
+        if not poly.point_inside(x, y):
+            continue
+        g = cellfun(x, y, params[:, i].tolist())
+        if not isinstance(g, GeomGroup):
+            msg = (
+                "The cellfun function must return a GeomGroup when called with "
+                "valid parameters."
+            )
+            raise TypeError(msg)
+        phc.group.extend(g.group)
 
     phc.translate(x0, y0)
     return phc

--- a/src/samplemaker/phc.py
+++ b/src/samplemaker/phc.py
@@ -10,10 +10,7 @@ as input (e.g. the radius of a circle) and produces a geometry.
 
 For example the default unit cell function is a circle defined as:
 
-    def __circ_cellfun__(x,y,params):
-    if params=="test":
-        return 1
-    else:
+    def make_phc_circle(x,y,params):
         return sm.make_circle(x, y, params[0], 0)
 
 The `Crystal` class provides a template for periodic structures consisting of an

--- a/tests/test_phc.py
+++ b/tests/test_phc.py
@@ -300,9 +300,11 @@ def test_make_phc_circle_creates_expected_circle() -> None:
     assert circle.r == pytest.approx(3.0)
 
 
-def test_make_phc_circle_ref_creates_expected_circle() -> None:
+def test_make_phc_circle_ref_creates_expected_circle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     reference_circle = make_phc_circle(x=0.0, y=0.0, params=[1.0])
-    LayoutPool["_CIRCLE"] = reference_circle
+    monkeypatch.setitem(LayoutPool, "_CIRCLE", reference_circle)
 
     circle_geom = make_phc_circle_ref(x=1.0, y=2.0, params=[3.0])
 

--- a/tests/test_phc.py
+++ b/tests/test_phc.py
@@ -5,8 +5,8 @@ from collections.abc import Sequence
 import numpy as np
 import pytest
 
-from samplemaker import LayoutPool
 import samplemaker.makers as sm
+from samplemaker import LayoutPool
 from samplemaker.phc import (
     Crystal,
     make_phc,

--- a/tests/test_phc.py
+++ b/tests/test_phc.py
@@ -289,14 +289,7 @@ def test_make_phc_uses_scaled_coordinates_and_translates() -> None:
     )
     calls: list[tuple[float, float, list[float]]] = []
 
-    def custom_cellfun(
-        x: float, y: float, params: Sequence[float] | str
-    ) -> GeomGroup | int:
-        if params == "test":
-            return 1
-        if isinstance(params, str):
-            msg = "Unexpected params value in custom_cellfun."
-            raise ValueError(msg)
+    def custom_cellfun(x: float, y: float, params: Sequence[float]) -> GeomGroup:
         calls.append((x, y, list(params)))
         return sm.make_circle(x, y, params[0], layer=7)
 
@@ -340,14 +333,7 @@ def test_make_phc_inpoly_filters_sites() -> None:
         layer=1,
     )
 
-    def custom_cellfun(
-        x: float, y: float, params: list[float] | str
-    ) -> GeomGroup | int:
-        if params == "test":
-            return 1
-        if isinstance(params, str):
-            msg = "Unexpected params value in custom_cellfun."
-            raise ValueError(msg)
+    def custom_cellfun(x: float, y: float, params: Sequence[float]) -> GeomGroup:
         return sm.make_circle(x, y, params[0], layer=3)
 
     g = make_phc_inpoly(

--- a/tests/test_phc.py
+++ b/tests/test_phc.py
@@ -5,9 +5,16 @@ from collections.abc import Sequence
 import numpy as np
 import pytest
 
+from samplemaker import LayoutPool
 import samplemaker.makers as sm
-from samplemaker.phc import Crystal, make_phc, make_phc_inpoly
-from samplemaker.shapes import Circle, GeomGroup, Poly
+from samplemaker.phc import (
+    Crystal,
+    make_phc,
+    make_phc_circle,
+    make_phc_circle_ref,
+    make_phc_inpoly,
+)
+from samplemaker.shapes import Circle, GeomGroup, Poly, SRef
 
 
 def _site_set(
@@ -281,6 +288,37 @@ def test_triangular_heterophc_fractional_nx_remains_x_symmetric() -> None:
     assert np.max(c.xpts) == pytest.approx(-np.min(c.xpts))
 
 
+def test_make_phc_circle_creates_expected_circle() -> None:
+    circle_geom = make_phc_circle(x=1.0, y=2.0, params=[3.0])
+
+    assert isinstance(circle_geom, GeomGroup)
+    assert len(circle_geom.group) == 1
+    circle = circle_geom.group[0]
+    assert isinstance(circle, Circle)
+    assert circle.x0 == pytest.approx(1.0)
+    assert circle.y0 == pytest.approx(2.0)
+    assert circle.r == pytest.approx(3.0)
+
+
+def test_make_phc_circle_ref_creates_expected_circle() -> None:
+    reference_circle = make_phc_circle(x=0.0, y=0.0, params=[1.0])
+    LayoutPool["_CIRCLE"] = reference_circle
+
+    circle_geom = make_phc_circle_ref(x=1.0, y=2.0, params=[3.0])
+
+    assert isinstance(circle_geom, GeomGroup)
+    assert len(circle_geom.group) == 1
+    circle_ref = circle_geom.group[0]
+    assert isinstance(circle_ref, SRef)
+    assert circle_ref.x0 == pytest.approx(1.0)
+    assert circle_ref.y0 == pytest.approx(2.0)
+    assert circle_ref.mag == pytest.approx(3.0)
+    assert circle_ref.angle == pytest.approx(0.0)
+    assert circle_ref.mirror is False
+    assert circle_ref.cellname == "_CIRCLE"
+    assert circle_ref.group is reference_circle
+
+
 def test_make_phc_uses_scaled_coordinates_and_translates() -> None:
     c = Crystal(
         xpts=[0.0, 2.0],
@@ -321,6 +359,71 @@ def test_make_phc_uses_scaled_coordinates_and_translates() -> None:
     assert circles[1].r == pytest.approx(20.0)
 
 
+def test_make_phc_returns_empty_group_for_empty_crystal() -> None:
+    c = Crystal()
+    g = make_phc(
+        crystal=c,
+        scaling=1.0,
+        cellparams=[5.0],
+        x0=0.0,
+        y0=0.0,
+    )
+    assert isinstance(g, GeomGroup)
+    assert len(g.group) == 0
+
+
+def test_make_phc_raises_on_invalid_crystal() -> None:
+    c_pts_mismatch = Crystal([1.0, 2.0], [3.0], [[1.0]])
+    c_incorrect_params_ndims = Crystal([1.0], [2.0], [1.0])  # type: ignore[arg-type]
+    c_incorrect_params_shape = Crystal([1.0, 2.0], [2.0, 2.0], [[1.0], [2.0]])
+
+    with pytest.raises(ValueError, match="x-coordinates must match"):
+        make_phc(
+            crystal=c_pts_mismatch,
+            scaling=1.0,
+            cellparams=[5.0],
+            x0=0.0,
+            y0=0.0,
+        )
+    with pytest.raises(ValueError, match="params array must be 2-dimensional"):
+        make_phc(
+            crystal=c_incorrect_params_ndims,
+            scaling=1.0,
+            cellparams=[5.0],
+            x0=0.0,
+            y0=0.0,
+        )
+    with pytest.raises(
+        ValueError, match="parameter sets must match the number of lattice sites"
+    ):
+        make_phc(
+            crystal=c_incorrect_params_shape,
+            scaling=1.0,
+            cellparams=[5.0],
+            x0=0.0,
+            y0=0.0,
+        )
+
+
+def test_make_phc_raises_on_mismatched_cellparams() -> None:
+    c = Crystal(
+        xpts=[0.0, 1.0],
+        ypts=[0.0, 1.0],
+        params=[[1.0, 2.0], [3.0, 4.0]],
+    )
+    with pytest.raises(
+        ValueError,
+        match="The number of cell parameters must match the number of parameter sets",
+    ):
+        make_phc(
+            crystal=c,
+            scaling=1.0,
+            cellparams=[5.0],  # Only one set of cell parameters
+            x0=0.0,
+            y0=0.0,
+        )
+
+
 def test_make_phc_inpoly_filters_sites() -> None:
     c = Crystal(
         xpts=[0.0, 2.0, -2.0],
@@ -351,3 +454,76 @@ def test_make_phc_inpoly_filters_sites() -> None:
     assert circles[0].x0 == pytest.approx(10.0)
     assert circles[0].y0 == pytest.approx(20.0)
     assert circles[0].r == pytest.approx(5.0)
+
+
+def test_make_phc_inpoly_returns_empty_group_for_empty_crystal() -> None:
+    c = Crystal()
+    poly = Poly(xpts=[0.0, 1.0], ypts=[0.0, 1.0], layer=1)
+    g = make_phc_inpoly(
+        crystal=c,
+        poly=poly,
+        scaling=1.0,
+        cellparams=[5.0],
+        x0=0.0,
+        y0=0.0,
+    )
+    assert isinstance(g, GeomGroup)
+    assert len(g.group) == 0
+
+
+def test_make_phc_inpoly_raises_on_invalid_crystal() -> None:
+    c_pts_mismatch = Crystal([1.0, 2.0], [3.0], [[1.0]])
+    c_incorrect_params_ndims = Crystal([1.0], [2.0], [1.0])  # type: ignore[arg-type]
+    c_incorrect_params_shape = Crystal([1.0, 2.0], [2.0, 2.0], [[1.0], [2.0]])
+    poly = Poly(xpts=[0.0, 1.0], ypts=[0.0, 1.0], layer=1)
+
+    with pytest.raises(ValueError, match="x-coordinates must match"):
+        make_phc_inpoly(
+            crystal=c_pts_mismatch,
+            poly=poly,
+            scaling=1.0,
+            cellparams=[5.0],
+            x0=0.0,
+            y0=0.0,
+        )
+    with pytest.raises(ValueError, match="params array must be 2-dimensional"):
+        make_phc_inpoly(
+            crystal=c_incorrect_params_ndims,
+            poly=poly,
+            scaling=1.0,
+            cellparams=[5.0],
+            x0=0.0,
+            y0=0.0,
+        )
+    with pytest.raises(
+        ValueError, match="parameter sets must match the number of lattice sites"
+    ):
+        make_phc_inpoly(
+            crystal=c_incorrect_params_shape,
+            poly=poly,
+            scaling=1.0,
+            cellparams=[5.0],
+            x0=0.0,
+            y0=0.0,
+        )
+
+
+def test_make_phc_inpoly_raises_on_mismatched_cellparams() -> None:
+    c = Crystal(
+        xpts=[0.0, 1.0],
+        ypts=[0.0, 1.0],
+        params=[[1.0, 2.0], [3.0, 4.0]],
+    )
+    poly = Poly(xpts=[-1.0, 1.0], ypts=[-1.0, 1.0], layer=1)
+    with pytest.raises(
+        ValueError,
+        match="The number of cell parameters must match the number of parameter sets",
+    ):
+        make_phc_inpoly(
+            crystal=c,
+            poly=poly,
+            scaling=1.0,
+            cellparams=[5.0],  # Only one set of cell parameters
+            x0=0.0,
+            y0=0.0,
+        )


### PR DESCRIPTION
This PR significantly improves the time it takes to generate photonic crystal geometries. The generation time, especially for large crystals, should now be several orders of magnitude before.

Also simplified the cell function structure required by `make_phc()` and `make_phc_inpoly()` as they no longer need to return the amount of arguments needed.