### PR TITLE
Fix: Repair Nix flake

### DIFF
--- a/.github/workflows/check_flake.yml
+++ b/.github/workflows/check_flake.yml
@@ -1,0 +1,16 @@
+name: "Check Nix flake"
+on:
+  pull_request:
+  push:
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+    - uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24  # v31.11.1
+      with:
+        github_access_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: "Check Nix flake"
+      run: nix flake check
+    - name: "Build Nix flake"
+      run: nix build

--- a/.github/workflows/check_flake.yml
+++ b/.github/workflows/check_flake.yml
@@ -6,11 +6,11 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
-    - uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24  # v31.11.1
-      with:
-        github_access_token: ${{ secrets.GITHUB_TOKEN }}
-    - name: "Check Nix flake"
-      run: nix flake check
-    - name: "Build Nix flake"
-      run: nix build
+      - uses: actions/checkout@v5
+      - uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24  # v31.11.1
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Check Nix flake"
+        run: nix flake check
+      - name: "Build Nix flake"
+        run: nix build

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780749050,
-        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
+        "lastModified": 1787070829,
+        "narHash": "sha256-vXNVDVtvfiQuXthP0NHPFdNvvMTkGpx0UP8oddIWbNk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
+        "rev": "0ae2bc1419c3f345984c2629e72e7a631820fa4d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,13 @@
           dependencies = [
             pyPkgs.matplotlib
             pyPkgs.numpy
+            pyPkgs.asteval
           ];
+
+          nativeCheckInputs = [
+            pyPkgs.pytestCheckHook
+          ];
+          enabledTestPaths = [ "tests/" ];
 
           # scikit-build-core invokes cmake internally; skip Nix's cmake configure hook
           dontUseCmakeConfigure = true;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 requires-python = ">=3.11,<3.15"
 license-files = ["LICENSE.md"]
 license = "BSD-3-Clause"
-version = "5.5.0"
+version = "5.5.1"
 dependencies = ["asteval>=1.0.9", "matplotlib>=3.10.5", "numpy==2.*"]
 classifiers = [
     "Programming Language :: C++",

--- a/uv.lock
+++ b/uv.lock
@@ -698,7 +698,7 @@ wheels = [
 
 [[package]]
 name = "samplemaker-sparrow"
-version = "5.5.0"
+version = "5.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "asteval" },

--- a/uv.lock
+++ b/uv.lock
@@ -698,7 +698,7 @@ wheels = [
 
 [[package]]
 name = "samplemaker-sparrow"
-version = "5.4.9"
+version = "5.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "asteval" },


### PR DESCRIPTION
- Fix missing `asteval` dependency in flake.
- Update `nixpkgs` flake input.
- Ensure `pytest` runs on `nix build`.
- Add workflow to avoid flake drift in the future.